### PR TITLE
Change unit test for challenge 02

### DIFF
--- a/02.py
+++ b/02.py
@@ -17,7 +17,7 @@ def product(numbers):
 class ProductTests(unittest.TestCase):
 
     def test_product(self):
-        self.assertEqual(     0, product([]))
+        self.assertEqual(     1, product([]))
         self.assertEqual(     0, product([0]))
         self.assertEqual(     1, product([1]))
         self.assertEqual(     5, product([5, 1]))


### PR DESCRIPTION
The first unit test for challenge 02 asserted that the product of an empty list should be 0, but it is generally accepted to be 1.

The reasoning behind this is that the integers form a monoid with the product (*), being its neutral element 1; while the lists form a monoid with the list concatenation (++), being its neutral element the empty list []. It is natural to expect the prod function to be a homomorphism between the two monoids, because it preserves the monoid structure, transforming \* into ++:

prod ([1,5,6] ++ [4,3])  =  prod([1,5,6]) \* prod([4,3])

Therefore, it would be reasonable to expect the prod function to transform a neutral element into a neutral element. Otherwise, we would be making the prod not to be an homomorphism:

prod([] ++ [1]) =/= prod([]) \* prod([1])
